### PR TITLE
Resample on the fly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Felix Cremer <fcremer@bgc-jena.mpg.de> and contributors"]
 version = "0.1.0"
 
 [deps]
+ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 DiskArrayEngine = "2d4b2e14-ccd6-4284-b8b0-2378ace7c126"
 DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
@@ -11,6 +12,7 @@ Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 ImageBase = "c817782e-172a-44cc-b673-b171935fbb9e"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+Proj = "c94c279d-25a6-4763-9509-64d165bea63e"
 Rasters = "a3a2b9e3-a471-40c9-b274-f788e487c689"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"


### PR DESCRIPTION
To plot the raster data on top of the base map
 we resample the small selection of the data 1000 by 1000 pixels on the fly to webmercator.
 This should be put into its own extension to reduce the dependencies.

As an interface we could dispatch on the Tyler.Map instead of using the axis directly to indicate, that we are going to do this resampling on the fly. 