### PR TITLE
Dont assume local storage

### DIFF
--- a/ext/PyramidSchemeArchGDALExt.jl
+++ b/ext/PyramidSchemeArchGDALExt.jl
@@ -1,10 +1,10 @@
 module PyramidSchemeArchGDALExt
 using ArchGDAL: ArchGDAL as AG
-using PyramidScheme: PyramidScheme as PS
+using PyramidScheme: PyramidScheme as PS, _pyramid_gdal
 using YAXArrays
 using DimensionalData
 
-function PS.Pyramid(path::AbstractString)
+function _pyramid_gdal(path::AbstractString)
     base = Cube(path)
     agbase = AG.readraster(path)
     band = AG.getband(agbase,1)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -13,7 +13,7 @@ function Base.copy(bc::Broadcasted{PyramidStyle})
         argslevel = levels.(inputs, (l,))
         argdata = getproperty.(argslevel, :data)
         newdata = func.(argdata...)
-        newdimarr = DD.rebuild(first(argslevel), data=newdata)
+        newdimarr = DD.rebuild(first(argslevel), data=newdata, dims=DD.dims(first(argslevel)))
         newdimarr
     end
     #@show typeof(newlevels)


### PR DESCRIPTION
This adds a few fixes so the code works with remote cubes. 

An example script is here:

````julia
using PyramidScheme, Zarr
const PS = PyramidScheme
using GLMakie
using DimensionalData.Dimensions
@dim lon XDim
@dim lat YDim
import DimensionalData as DD
replacenan(i) = i<=0 ? NaN32 : Float32(i)
p2020 = replacenan.(PS.Pyramid("https://s3.bgc-jena.mpg.de:9000/pyramids/ESACCI-BIOMASS-L4-AGB-MERGED-100m-2020-fv4.0.zarr"))
p2017 = replacenan.(PS.Pyramid("https://s3.bgc-jena.mpg.de:9000/pyramids/ESACCI-BIOMASS-L4-AGB-MERGED-100m-2017-fv4.0.zarr"))

pdiff = p2020 .- p2017
plot(pdiff, colormap = :curl)
````