### PR TITLE
Add tilepyramids to PyramidScheme

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,23 +11,29 @@ DiskArrayEngine = "2d4b2e14-ccd6-4284-b8b0-2378ace7c126"
 DiskArrayTools = "fcd2136c-9f69-4db6-97e5-f31981721d63"
 DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
+MapTiles = "fea52e5a-b371-463b-85f5-81770daa2737"
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Proj = "c94c279d-25a6-4763-9509-64d165bea63e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+TileProviders = "263fe934-28e1-4ae9-998a-c2629c5fede6"
 YAXArrayBase = "90b8fcef-0c2d-428d-9c56-5f86629e9d14"
 YAXArrays = "c21b50f5-aa40-41ea-b809-c0f5e47bfa5c"
 Zarr = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 
 [weakdeps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
+Tyler = "e170d443-b9d6-418a-9ee8-061e966341ef"
 
 [extensions]
 PyramidSchemeArchGDALExt = "ArchGDAL"
+PyramidSchemeTylerExt = "Tyler"
 
 [compat]
 Aqua = "0.8"

--- a/ext/PyramidSchemeTylerExt.jl
+++ b/ext/PyramidSchemeTylerExt.jl
@@ -1,0 +1,41 @@
+module PyramidSchemeTylerExt
+import Tyler
+import PyramidScheme: PyramidProvider, selectlevel_tile
+import MapTiles: Tile, extent
+import Colors: RGB
+import ColorSchemes: colorschemes
+import DimensionalData: DimArray, Near
+import TileProviders
+
+function Tyler.fetch_tile(p::PyramidProvider, tile::Tile)
+    ext = extent(tile, wgs84)
+    data = try
+        selectlevel_tile(p.p, ext, target_imsize=(256, 256))
+    catch e
+        println("Error getting extent $ext")
+        println(e)
+        return fill(RGB{Float64}(1.0, 1.0, 1.0), 256, 256)
+    end
+    if isempty(data)
+        return fill(RGB{Float64}(1.0, 1.0, 1.0), 256, 256)
+    end
+    ar = DimArray(data.data, data.axes)
+    cs = colorschemes[p.colorscheme]
+    inner_lon_step = (ext.X[2] - ext.X[1]) / 256
+    inner_lat_step = (ext.Y[2] - ext.Y[1]) / 256
+    inner_lons = range(ext.X..., length=257) .+ inner_lon_step / 2
+    inner_lats = range(ext.Y..., length=257) .+ inner_lat_step / 2
+    map(CartesianIndices((256:-1:1, 1:256))) do I
+        ilat, ilon = I.I
+        v = ar[lon=Near(inner_lons[ilon]), lat=Near(inner_lats[ilat])] |> only
+        if isnan(v) || ismissing(v) || isinf(v)
+            p.nodatacolor
+        else
+            cs[(v-p.data_min)/(p.data_max-p.data_min)]
+        end
+    end
+end
+TileProviders.max_zoom(p::PyramidProvider) = p.max_zoom
+TileProviders.min_zoom(p::PyramidProvider) = p.min_zoom
+
+end

--- a/src/PyramidScheme.jl
+++ b/src/PyramidScheme.jl
@@ -24,6 +24,7 @@ using Proj
 using Makie: Axis, Colorbar, DataAspect, Figure, FigureAxisPlot, Observable, Relative
 using Makie: on, heatmap!, image!
 import MakieCore: plot, plot!
+import DiskArrays: cache
 using OffsetArrays
 
 using Statistics
@@ -290,6 +291,11 @@ function gen_output(t,s; path=tempname())
         zeros(t,s...)
     end
 end
+
+function cache(p::Pyramid; maxsize=1000)
+    maxsize = maxsize ÷ (length(p.levels) + 1)
+    Pyramid(cache(p.base; maxsize), cache.(p.levels; maxsize), p.metadata)
+end
 function DiskArrayEngine.engine(dimarr::DD.AbstractDimArray) 
     dataengine = engine(dimarr.data)
     DD.rebuild(dimarr, data=dataengine)
@@ -527,6 +533,8 @@ function tms_json(pyramid)
 end
 
 include("broadcast.jl")
+include("pyramidprovider.jl")
+include("tilepyramids.jl")
 
 
 end

--- a/src/pyramidprovider.jl
+++ b/src/pyramidprovider.jl
@@ -1,0 +1,50 @@
+import TileProviders
+import Colors: RGB
+import HTTP
+import FileIO: save, Stream, @format_str
+
+struct PyramidProvider{P<:Pyramid} <: TileProviders.AbstractProvider
+    p::P
+    min_zoom::Int
+    max_zoom::Int
+    data_min::Float64
+    data_max::Float64
+    colorscheme::Symbol
+    nodatacolor::RGB{Float64}
+end
+PyramidProvider(p::Pyramid, data_min, data_max; min_zoom=0, max_zoom=15, colorscheme=:viridis, nodatacolor=RGB{Float64}(1.0, 1.0, 1.0)) =
+    PyramidProvider(p, min_zoom, max_zoom, data_min, data_max, colorscheme, nodatacolor)
+
+function selectlevel_tile(pyramid, ext; target_imsize=(256, 256))
+    pyrext = extent(pyramid)
+    basepixels = map(pyrext, ext, size(pyramid)) do bbpyr, bbext, spyr
+        pyrspan = bbpyr[2] - bbpyr[1]
+        imsize = bbext[2] - bbext[1]
+        imsize / pyrspan * spyr
+    end
+    dimlevels = log2.(basepixels ./ target_imsize)
+    minlevel = minimum(dimlevels)
+    n_agg = min(max(floor(Int, minlevel), 0), nlevels(pyramid))
+    @debug "Selected level $n_agg"
+    extcorrectnames = Extent{keys(pyrext)}(tuple(bounds(ext)...))
+    levels(pyramid)[n_agg][extcorrectnames]
+end
+
+function provider_request_handler(p::PyramidProvider)
+    request -> begin
+        k = request.target
+        k = lstrip(k, '/')
+        m = match(r"(\d+)/(\d+)/(\d+).png", k)
+        if m === nothing
+            return HTTP.Response(404, "Error: Malformed url")
+        end
+        z, x, y = tryparse.(Int, m.captures)
+        any(isnothing, (x, y, z)) && return HTTP.Response(404, "Error: Malformed url")
+        data = Tyler.fetch_tile(p, Tile(x, y, z))
+        buf = IOBuffer()
+        save(Stream{format"PNG"}(buf), data)
+        return HTTP.Response(200, take!(buf))
+    end
+end
+HTTP.serve(p::PyramidProvider, args...; kwargs...) = HTTP.serve(provider_request_handler(p), args...; kwargs...)
+HTTP.serve!(p::PyramidProvider, args...; kwargs...) = HTTP.serve!(provider_request_handler(p), args...; kwargs...)

--- a/src/tilepyramids.jl
+++ b/src/tilepyramids.jl
@@ -1,0 +1,106 @@
+import DiskArrays
+import TileProviders: AbstractProvider
+import Colors: RGB, RGBA
+import HTTP
+import FileIO
+import MapTiles: Tile, extent, web_mercator
+import DimensionalData: Dim, X, Y
+
+"DiskArray representing maptiles as 2d or 3d arrays with bands"
+struct MapTileDiskArray{T,N,P<:AbstractProvider} <: DiskArrays.ChunkTiledDiskArray{T,N}
+    prov::P
+    zoom::Int
+    tilesize::Int
+    nband::Int
+end
+function MapTileDiskArray(prov, zoom, mode=:band)
+    testtile = load_data(prov, zoom, 0, 0)
+    et = eltype(testtile)
+    nband = if et <: RGB
+        3
+    elseif et <: RGBA
+        4
+    else
+        error("Unknown color type $et")
+    end
+    if mode === :band
+        return MapTileDiskArray{rgbeltype(et),3,typeof(prov)}(prov, zoom, size(testtile, 1), nband)
+    elseif mode === :rgb
+        return MapTileDiskArray{et,2,typeof(prov)}(prov, zoom, size(testtile, 1), nband)
+    else
+        error("Unknown mode $mode")
+    end
+end
+DiskArrays.eachchunk(a::MapTileDiskArray{<:Any,3}) = DiskArrays.GridChunks((a.nband, a.tilesize * 2^a.zoom, a.tilesize * 2^a.zoom), (a.nband, a.tilesize, a.tilesize))
+DiskArrays.eachchunk(a::MapTileDiskArray{<:Any,2}) = DiskArrays.GridChunks((a.tilesize * 2^a.zoom, a.tilesize * 2^a.zoom), (a.tilesize, a.tilesize))
+
+DiskArrays.haschunks(::MapTileDiskArray) = DiskArrays.Chunked()
+
+rgbeltype(::Type{RGB{T}}) where {T} = T
+rgbeltype(::Type{RGBA{T}}) where {T} = T
+function Base.getindex(a::MapTileDiskArray{<:Any,3}, i::DiskArrays.ChunkIndex{3,DiskArrays.OneBasedChunks})
+    _, y, x = i.I.I
+    data = load_data(a.prov, a.zoom, x - 1, y - 1)
+    T = rgbeltype(eltype(data))
+    data = reinterpret(reshape, T, data)
+    return DiskArrays.wrapchunk(data, DiskArrays.eachchunk(a)[i.I])
+end
+
+function Base.getindex(a::MapTileDiskArray{<:Any,2}, i::DiskArrays.ChunkIndex{2,DiskArrays.OneBasedChunks})
+    y, x = i.I.I
+    data = load_data(a.prov, a.zoom, x - 1, y - 1)
+    return DiskArrays.wrapchunk(data, DiskArrays.eachchunk(a)[i.I])
+end
+
+function load_data(prov, zoom, x, y)
+    url = TileProviders.geturl(prov, x, y, zoom)
+    result = HTTP.get(url; retry=false, readtimeout=4, connect_timeout=4)
+    if result.status > 300
+        if result.status == 404
+            return nothing
+        else
+            throw(ErrorException("HTTP error $(result.status)"))
+        end
+    else
+        io = IOBuffer(result.body)
+        format = FileIO.query(io)
+        FileIO.load(format)
+    end
+end
+
+function dimsfromzoomlevel(zoom, tilesize)
+    t1 = Tile(1, 1, zoom)
+    ntiles = 2^zoom
+    npix = ntiles * tilesize
+    t2 = Tile(ntiles, ntiles, zoom)
+    ex1 = extent(t1, web_mercator)
+    ex2 = extent(t2, web_mercator)
+    x1, x2 = first(ex1.X), last(ex2.X)
+    y1, y2 = first(ex1.Y), last(ex2.Y)
+    stepx = (x2 - x1) / npix
+    stepy = (y2 - y1) / npix
+    x = X(range(x1 + stepx / 2, x2 - stepx / 2, length=npix))
+    y = Y(range(y1 + stepy / 2, y2 - stepy / 2, length=npix))
+    return x, y
+end
+function provtoyax(prov, zoom, mode=:band)
+    a = MapTileDiskArray(prov, zoom, mode)
+    xdim, ydim = dimsfromzoomlevel(zoom, a.tilesize)
+    if mode === :band
+        coldim = if a.nband == 3
+            Dim{:Band}(["Red", "Green", "Blue"])
+        elseif a.nband == 4
+            Dim{:Band}(["Red", "Green", "Blue", "Alpha"])
+        end
+        YAXArray((coldim, ydim, xdim), a)
+    else
+        YAXArray((ydim, xdim), a)
+    end
+end
+
+function Pyramid(prov::AbstractProvider, mode=:band)
+    maxzoom = get(prov.options, :max_zoom, 18)
+    base = provtoyax(prov, maxzoom, mode)
+    levels = [provtoyax(prov, zoom, mode) for zoom in (maxzoom-1):-1:0]
+    return Pyramid(base, levels, prov.options)
+end


### PR DESCRIPTION
This adds abstraction layers to treat any Pyramid as a TileProvider and also adds a `Pyramid` constructor to lazily expose a TileProvider as a Pyramid.  